### PR TITLE
Use buffer instead of string to get appropriate 'Content-Length' header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,7 @@ module.exports = (function() {
     this.validationMode = originalValidationMode; // Reset since we no longer need it to build the XML..
 
     var url = this.getPostUrl();
+    var content = new Buffer(string, 'utf-8');
 
     var req = https.request({
       host: url.host,
@@ -82,12 +83,12 @@ module.exports = (function() {
       requestCert: options.requestCert || true,
       agent: options.agent || false,
       headers: {
-        'Content-Length': string.length,
+        'Content-Length': content.length,
         'Content-Type': 'text/xml'
       }
     });
 
-    req.write(string);
+    req.write(content);
     req.on('error', function(err) {
       callback(err);
     })


### PR DESCRIPTION
If this could be merged pronto I'd be oh so happy :+1: 